### PR TITLE
Fixing a bug related to the dragging

### DIFF
--- a/Example.html
+++ b/Example.html
@@ -95,9 +95,12 @@
         zones[2].style.width = `${dragBarPercentX * 100}%`;
     });
 
-    graph.addEventListener('mouseup', () => {
+    window.addEventListener('mouseup', () => {
         isDragging = false;
     });
+    window.addEventListener('mouseleave', () => {
+        isDragging = false;
+    })
 </script>
 </body>
 </html>


### PR DESCRIPTION
Currently, isDragging is only set to false if the cursor lifts up on the graph element, this makes it so it is set to false if the cursor lifts up anywhere on the window or leaves the window